### PR TITLE
모바일 대응 navigationLinks 햄버거 메뉴 추가

### DIFF
--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -100,8 +100,6 @@ export const NotionPageHeader: React.FC<{
                     )}
                   >
                     <svg
-                      stroke="#37352f"
-                      fill="#37352f"
                       strokeWidth="0"
                       width="14px"
                       height="14px"

--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -49,7 +49,7 @@ export const NotionPageHeader: React.FC<{
         <div className="notion-nav-header-rhs breadcrumbs">
           {navigationLinks
             ?.map((link, index) => {
-              if (!link.pageId && !link.url) {
+              if ((!link.pageId && !link.url) || link.menuPage) {
                 return null;
               }
 
@@ -58,17 +58,17 @@ export const NotionPageHeader: React.FC<{
                   <components.PageLink
                     href={mapPageUrl(link.pageId)}
                     key={index}
-                    className={cs(styles.navLink, 'breadcrumb', 'button')}
+                    className={cs(styles.navLink, 'breadcrumb', 'button', 'notion-nav-header-wide')}
                   >
                     {link.title}
                   </components.PageLink>
                 );
-              } else {
+              } else if (link.url) {
                 return (
                   <components.Link
                     href={link.url}
                     key={index}
-                    className={cs(styles.navLink, 'breadcrumb', 'button')}
+                    className={cs(styles.navLink, 'breadcrumb', 'button', 'notion-nav-header-wide')}
                   >
                     {link.title}
                   </components.Link>
@@ -80,6 +80,42 @@ export const NotionPageHeader: React.FC<{
           <ToggleThemeButton />
 
           {isSearchEnabled && <Search block={block} title={null} />}
+
+          {navigationLinks
+            ?.map((link, index) => {
+              if (!link.pageId && !link.url) {
+                return null;
+              }
+
+              if (link.menuPage == true) {
+                return (
+                  <components.PageLink
+                    href={mapPageUrl(link.pageId)}
+                    key={index}
+                    className={cs(
+                      styles.navLink,
+                      'breadcrumb',
+                      'button',
+                      'notion-nav-header-mobile',
+                    )}
+                  >
+                    <svg
+                      stroke="#37352f"
+                      fill="#37352f"
+                      strokeWidth="0"
+                      width="14px"
+                      height="14px"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path d="M0 0h24v24H0z" fill="none" />
+                      <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
+                    </svg>
+                  </components.PageLink>
+                );
+              }
+            })
+            .filter(Boolean)}
         </div>
       </div>
     </header>

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -45,6 +45,7 @@ export interface NavigationLink {
   title: string;
   pageId?: string;
   url?: string;
+  menuPage?: boolean;
 }
 
 export const siteConfig = (config: SiteConfig): SiteConfig => {

--- a/site.config.ts
+++ b/site.config.ts
@@ -55,6 +55,7 @@ export default siteConfig({
     {
       title: '카테고리',
       pageId: '36400db511474331b5c1de6918212469',
+      menuPage: true,
     },
   ],
 

--- a/site.config.ts
+++ b/site.config.ts
@@ -55,6 +55,10 @@ export default siteConfig({
     {
       title: '카테고리',
       pageId: '36400db511474331b5c1de6918212469',
+    },
+    {
+      title: '카테고리',
+      pageId: '36400db511474331b5c1de6918212469',
       menuPage: true,
     },
   ],

--- a/styles/custom/notion.scss
+++ b/styles/custom/notion.scss
@@ -59,6 +59,10 @@ body {
     .notion-nav-header {
       max-width: var(--notion-max-width);
     }
+
+    .breadcrumb.notion-nav-header-mobile svg {
+      fill: var(--fg-color);
+    }
   }
 
   // 다크모드 아닐때

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -39,8 +39,23 @@
   margin: 0 auto;
 }
 
-.notion-nav-header-rhs {
+.notion-nav-header-wide {
+  display: inline-flex;
   gap: 0.5rem;
+}
+
+.notion-nav-header-mobile {
+  display: none !important;
+}
+
+@media (max-width: 1023px) {
+  .notion-nav-header-wide {
+    display: none !important;
+  }
+
+  .notion-nav-header-mobile {
+    display: inline-flex !important;
+  }
 }
 
 .notion-gallery-grid {


### PR DESCRIPTION
`site.config.ts`에서 `navigationLinks`가 많아지면 아래와 같이 글씨/버튼이 겹치고, 링크들이 잘리는 문제가 있습니다.

![image](https://github.com/2skydev/Notion-Next.js-blog-starter-kit/assets/39976362/737f921a-457f-438d-b409-1f4a0137aac9)

화면이 좁아지면 다음과 같이 기존의 상단 메뉴를 숨기고, 대신 햄버거 메뉴 버튼을 보여줍니다.

![image](https://github.com/2skydev/Notion-Next.js-blog-starter-kit/assets/39976362/1e626eab-58d5-49ee-bffb-00b9312519e3)

해당 햄버거 메뉴는 modal이 아닌 기존과 동일한 `pageId` 혹은 `url`로 이동하는 버튼이며, 다음과 같이 `site.config.ts`의 `navigationLinks`에 `menuPage`를 추가하는 것으로 지정합니다.

```
{
  title: '카테고리',
  pageId: '36400db511474331b5c1de6918212469',
  menuPage: true,
},
```